### PR TITLE
[Bug Fix] Don't use hardcoded path to Transforms.csv file

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -95,7 +95,8 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     VTKObservationMixin.__init__(self)  # needed for parameter node observation
 
     self.logic = None
-    with open("D:\Desktop\SlicerTrack\Track\Data\Transforms.csv", 'r') as read_transforms:
+    transformationsPath = os.path.join(os.path.dirname(__file__), 'Data/Transforms.csv')
+    with open(transformationsPath, 'r') as read_transforms:
         csv_reader = csv.reader(read_transforms)
         next(csv_reader)
         self.csv = list(csv_reader)


### PR DESCRIPTION
## Description

This PR intends to fix the following bug:
https://github.com/laboratory-for-translational-medicine/SlicerTrack/issues/1

We now get the path for `Transforms.csv` relative to the location of the SliceTrack repo.

## Testing

Tested on Ubuntu