### PR TITLE
[SlicerTrack][UI] Implement button for 2D time-series images input

### DIFF
--- a/Track/Resources/UI/Track.ui
+++ b/Track/Resources/UI/Track.ui
@@ -25,7 +25,7 @@
         </widget>
       </item>
       <item row="0" column="1">
-        <widget class="ctkPathLineEdit" name="2DTimeSeriesFolder">
+        <widget class="ctkPathLineEdit" name="Folder2DTimeSeries">
           <property name="filters">
             <set>ctkPathLineEdit::Dirs</set>
           </property>


### PR DESCRIPTION
## Description

Following up with task # 4 from our [design specification](https://github.com/laboratory-for-translational-medicine/SlicerTrack/issues/4), this PR implements a new button to select the folder which holds the set of 2D times series images/data to be used.

Note: This PR only implements the button in the UI, the logic will come hereafter

## Testing

Tested on Ubuntu