### PR TITLE
[SlicerTrack] Clean code and align to 3D Slicer observer MVC pattern as pre-implementation step

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -223,7 +223,6 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     Called when the application closes and the module widget is destroyed.
     """
     self.removeObservers()
-    self.logic.ClearNodes()
 
   def enter(self):
     """
@@ -350,12 +349,13 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     Begin playback when user clicks the "Play" button.
     """
     
-    with slicer.util.tryWithErrorDisplay("Failed to compute results.", waitCursor=True):
+    #with slicer.util.tryWithErrorDisplay("Failed to compute results.", waitCursor=True):
       # Compute output
       # TODO: change this to logic.play()
       #self.logic.process(self.ui.inputSelector.currentNode(), self.ui.outputSelector.currentNode(),
       #                   self.ui.imageThresholdSliderWidget.value, self.ui.invertOutputCheckBox.checked)
 
+    return
 
 #
 # TrackLogic


### PR DESCRIPTION
## Description

The purpose of this PR is to clean much of the parameter node antagonistic code within our SlicerTrack module. Without the parameter node we cannot successfully update the GUI as 3D Slicer had designed it to work.

This is a first step to resolving the issue: https://github.com/laboratory-for-translational-medicine/SlicerTrack/issues/3

The next step would be implement the parameter node, with the appropriate values/parameters.

# Testing

Tested on Ubuntu