### PR TITLE
[SlicerTrack] Enable usage of parameter node with 2D images input

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -370,7 +370,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           shNode.SetItemParent(imageID, folderID)
 
         # We do the following to clear the view of the slices. I expected {"show": False} to
-        # to prevent anything from being shown at all, but the first loaded image appears in the
+        # prevent anything from being shown at all, but the first loaded image will appear in the
         # foreground. This seems to be a bug in 3D Slicer.
         layoutManager = slicer.app.layoutManager()
         for viewName in layoutManager.sliceViewNames():


### PR DESCRIPTION
## Description

The purpose of this PR is to enable the parameter node to be used with the 2D time-series images input selector. This PR is the first step in migrating the logic from the Temp module (see https://github.com/laboratory-for-translational-medicine/SlicerTrack/issues/5) into the SlicerTrack module.

## Testing

Tested on Ubuntu
Tested on Windows