### PR TITLE
[SlicerTrack] Integrate 3D segmentation importation with parameter node

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -430,7 +430,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def clearSliceForegrounds(self):
     """
     Clear each slice view from having anything visible in the foreground. This often happens
-    inadvertantly when using loadVolume() with "show" set to False.
+    inadvertently when using loadVolume() with "show" set to False.
     """
     layoutManager = slicer.app.layoutManager()
     for viewName in layoutManager.sliceViewNames():


### PR DESCRIPTION
## Description

The purpose of this PR is to enable the importation of the 3D segmentation within SlicerTrack. This PR also enables the use of the parameter node with the 3D segmentation selector.

## Testing

Tested on Ubuntu
Tested on Windows