### PR TITLE
[SlicerTrack] Fix module reload bug

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -286,6 +286,12 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     if inputParameterNode:
       self.logic.setDefaultParameters(inputParameterNode)
+      # If the provided parameter node indicates that we had already loaded the 2D images, note the
+      # total images amount within the corresponding variable, as it may have been lost on reload.
+      if inputParameterNode.GetParameter("VirtualFolder2DImages"):
+        shNode = slicer.mrmlScene.GetSubjectHierarchyNode()
+        folderID = int(inputParameterNode.GetParameter("VirtualFolder2DImages"))
+        self.logic.totalImages = shNode.GetNumberOfItemChildren(folderID)
 
     # Unobserve previously selected parameter node and add an observer to the newly selected.
     # Changes of parameter node are observed so that whenever parameters are changed by a script or any other module
@@ -382,6 +388,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Set a param to hold the ID of a virtual folder within the subject hierarchy which holds
         # the 2D time-series images
         self._parameterNode.SetParameter("VirtualFolder2DImages", str(folderID))
+        # Track the number of total images within the variable totalImages
         self.logic.totalImages = shNode.GetNumberOfItemChildren(folderID)
       else:
         slicer.util.warningDisplay("No image files were found within the folder: "


### PR DESCRIPTION
## Description

When the module is reloaded (i.e. the module is destroyed and then recreated while being provided the same parameter node) an error would appear that would indicate the `totalImages` variable was `None`. This was because after the module was re-created, `totalImages` was given it's default value (`None`) and it was never set to the number of images within the 2D images virtual folder.

This PR fixes the bug by setting the `totalImages` var in the `setParameterNode()` function, which is called after the module is created. If it finds the 2D images folder in the provided parameter node, it will set the `totalImages` variable accordingly.

## Testing
Ubuntu
Windows