### PR TITLE
[SlicerTrack][Logic] Enable FPS input to change the delay between each step/frame

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -699,7 +699,6 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.logic.timer.singleShot(self.logic.delay,
                                 lambda: slicer.mrmlScene.InvokeEvent(self.AlignmentEvent))
 
-
   def onAlignmentComplete(self, caller, event):
     """
     Function invoked when the alignment of the 3D segmentation using the transformation data is
@@ -761,9 +760,11 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
   def onFPSChange(self):
     """
+    This function updates our delay value according to what is within the FPS input box. A frame
+    is considered as every time the program pauses to show the user the something in the GUI. These
+    pauses occurs in two places during playback: after visualize() and after align().
     """
     self.logic.delay = 1000 / self.fpsInputBox.value
-    print(self.logic.delay)
 
 #
 # TrackLogic

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -139,16 +139,16 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.stopSequenceButton.setSizePolicy(qt.QSizePolicy.Minimum, qt.QSizePolicy.Minimum)
     self.controlLayout.addWidget(self.stopSequenceButton)
 
-    # Fps label and spinbox
+    # FPS label and spinbox
     fpsLabel = qt.QLabel("FPS:")
     fpsLabel.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Minimum)
     self.controlLayout.addWidget(fpsLabel)
 
-    self.fps = qt.QSpinBox()
-    self.fps.minimum = 1
-    self.fps.maximum = 24
-    self.fps.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Minimum)
-    self.controlLayout.addWidget(self.fps)
+    self.fpsInputBox = qt.QSpinBox()
+    self.fpsInputBox.minimum = 1
+    self.fpsInputBox.maximum = 30
+    self.fpsInputBox.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Minimum)
+    self.controlLayout.addWidget(self.fpsInputBox)
 
     # Increment and Decrement frame button
     self.changeFrameWidget = qt.QWidget()
@@ -209,6 +209,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.stopSequenceButton.connect("clicked(bool)", self.onStopButton)
     self.incrementFrame.connect("clicked(bool)", self.onIncrement)
     self.decrementFrame.connect("clicked(bool)", self.onDecrement)
+    self.fpsInputBox.connect("valueChanged(int)", self.onFPSChange)
     self.sequenceSlider.connect("valueChanged(int)",
                                 lambda: self.sequenceFrameLabel.setText(self.sequenceSlider.value))
 
@@ -757,6 +758,12 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.stopSequenceButton.enabled = False
       self.incrementFrame.enabled = False
       self.decrementFrame.enabled = False
+
+  def onFPSChange(self):
+    """
+    """
+    self.logic.delay = 1000 / self.fpsInputBox.value
+    print(self.logic.delay)
 
 #
 # TrackLogic


### PR DESCRIPTION
## Description

This PR enables the use of the FPS input box so that it can affect the delay that occurs between each frame/step in the sequence.

Ex. If the FPS is 4, the delay will be 1000 ms / 4 = 250 ms (each frame/step will wait 250ms before moving to the next)

## Testing
Ubuntu
Windows