### PR TITLE
[SlicerTrack] Implement loading/progress bar for images/transformation data importation

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -483,6 +483,10 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     # Create a folder to hold the transform nodes
     sceneID = shNode.GetSceneItemID()
     transformsVirtualFolderID = shNode.CreateFolderItem(sceneID, "Transforms")
+    progressDialog = qt.QProgressDialog("Creating Transform Nodes From Transformation Data", "Cancel",
+                                        0, numImages)
+    progressDialog.minimumDuration = 0
+    progressCount = 0
 
     for i in range(numImages):
       imageID = imagesIDs[i]
@@ -521,6 +525,11 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       # Add the transform node to the transform nodes virtual folder
       transformNodeID = shNode.GetItemByDataNode(transformNode)
       shNode.SetItemParent(transformNodeID, transformsVirtualFolderID)
+
+      progressCount += 1
+      progressDialog.setValue(progressCount)
+      slicer.util.forceRenderAllViews()
+      slicer.app.processEvents()
 
     print(f"{len(transforms)} transforms were loaded into 3D Slicer as transform nodes")
     return transformsVirtualFolderID
@@ -580,6 +589,10 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     if len(imageFiles) != 0:
       sceneID = shNode.GetSceneItemID()
       folderID = shNode.CreateFolderItem(sceneID, "2D Time-Series Images")
+      progressDialog = qt.QProgressDialog("Loading 2D Images Into 3D Slicer", "Cancel",
+                                          0, len(imageFiles))
+      progressDialog.minimumDuration = 0
+      progressCount = 0
 
       print(f"{len(imageFiles)} 2D time-series images will be loaded into 3D Slicer")
 
@@ -589,6 +602,10 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Place image into the virtual folder
         imageID = shNode.GetItemByDataNode(loadedImageNode)
         shNode.SetItemParent(imageID, folderID)
+        progressCount += 1
+        progressDialog.setValue(progressCount)
+        slicer.util.forceRenderAllViews()
+        slicer.app.processEvents()
 
       # We do the following to clear the view of the slices. I expected {"show": False} to
       # prevent anything from being shown at all, but the first loaded image will appear in the

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -483,6 +483,8 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     # Create a folder to hold the transform nodes
     sceneID = shNode.GetSceneItemID()
     transformsVirtualFolderID = shNode.CreateFolderItem(sceneID, "Transforms")
+
+    # Create a progress/loading bar to display the progress of the node creation process
     progressDialog = qt.QProgressDialog("Creating Transform Nodes From Transformation Data", "Cancel",
                                         0, numImages)
     progressDialog.minimumDuration = 0
@@ -526,8 +528,11 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       transformNodeID = shNode.GetItemByDataNode(transformNode)
       shNode.SetItemParent(transformNodeID, transformsVirtualFolderID)
 
+      # Update how far we are in the progress bar
       progressCount += 1
       progressDialog.setValue(progressCount)
+
+      # This render step is needed for the progress bar to visually update in the GUI
       slicer.util.forceRenderAllViews()
       slicer.app.processEvents()
 
@@ -589,6 +594,8 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     if len(imageFiles) != 0:
       sceneID = shNode.GetSceneItemID()
       folderID = shNode.CreateFolderItem(sceneID, "2D Time-Series Images")
+
+      # Create a progress/loading bar to display the progress of the images loading process
       progressDialog = qt.QProgressDialog("Loading 2D Images Into 3D Slicer", "Cancel",
                                           0, len(imageFiles))
       progressDialog.minimumDuration = 0
@@ -602,8 +609,12 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Place image into the virtual folder
         imageID = shNode.GetItemByDataNode(loadedImageNode)
         shNode.SetItemParent(imageID, folderID)
+
+        #  Update how far we are in the progress bar
         progressCount += 1
         progressDialog.setValue(progressCount)
+
+        # This render step is needed for the progress bar to visually update in the GUI
         slicer.util.forceRenderAllViews()
         slicer.app.processEvents()
 


### PR DESCRIPTION
## Description

When using the SlicerTrack extension loading the 2D images and the transformation data from the transforms file can take a bit of time, and the GUI is frozen while this is happening. This slowness is exacerbated on slower systems.

This PR implements a progress bar dialog which is shown at these importation steps. The bar allows the user to anticipate how much longer it will take to load the data into 3D Slicer.

This PR intends to close https://github.com/laboratory-for-translational-medicine/SlicerTrack/issues/34

## Testing
Ubuntu
Windows