### PR TITLE
[SlicerTrack][Logic] Clear Overlay on the 2D images

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1043,7 +1043,6 @@ class TrackLogic(ScriptedLoadableModuleLogic):
       # Clear label map layer (the green overlay on the slice)
       for name in layoutManager.sliceViewNames():
         sliceWidget = layoutManager.sliceWidget(name)
-        labelMapNode = shNode.GetItemDataNode(int(segmentationLabelMapID))
         sliceCompositeNode = sliceWidget.mrmlSliceCompositeNode()
         sliceCompositeNode.SetLabelVolumeID("")
 

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1040,6 +1040,12 @@ class TrackLogic(ScriptedLoadableModuleLogic):
     if segmentationLabelMapID:
       shNode = slicer.mrmlScene.GetSubjectHierarchyNode()
       shNode.SetItemDisplayVisibility(int(segmentationLabelMapID), 0)
+      # Clear label map layer (the green overlay on the slice)
+      for name in layoutManager.sliceViewNames():
+        sliceWidget = layoutManager.sliceWidget(name)
+        labelMapNode = shNode.GetItemDataNode(int(segmentationLabelMapID))
+        sliceCompositeNode = sliceWidget.mrmlSliceCompositeNode()
+        sliceCompositeNode.SetLabelVolumeID("")
 
     slicer.util.forceRenderAllViews()
     slicer.app.processEvents()


### PR DESCRIPTION
### **Description**

The overlay on 2D images are cleared when resetState() is called.

This PR intends to close #60 

### **Testing**
MacOS (Version 5.2.2 - Stable Release and Version 5.3.0 - Preview Release)