### PR TITLE
[SlicerTrack][Logic] Clear Overlay on the 2D images

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1035,16 +1035,12 @@ class TrackLogic(ScriptedLoadableModuleLogic):
       sliceCompositeNode = sliceWidget.mrmlSliceCompositeNode()
       sliceCompositeNode.SetBackgroundVolumeID("None")
       sliceCompositeNode.SetForegroundVolumeID("None")
+      sliceCompositeNode.SetLabelVolumeID("")
 
     # Clear segmentation label map from 3D view (only if the label map exists)
     if segmentationLabelMapID:
       shNode = slicer.mrmlScene.GetSubjectHierarchyNode()
       shNode.SetItemDisplayVisibility(int(segmentationLabelMapID), 0)
-      # Clear label map layer (the green overlay on the slice)
-      for name in layoutManager.sliceViewNames():
-        sliceWidget = layoutManager.sliceWidget(name)
-        sliceCompositeNode = sliceWidget.mrmlSliceCompositeNode()
-        sliceCompositeNode.SetLabelVolumeID("")
 
     slicer.util.forceRenderAllViews()
     slicer.app.processEvents()

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1040,6 +1040,11 @@ class TrackLogic(ScriptedLoadableModuleLogic):
     if segmentationLabelMapID:
       shNode = slicer.mrmlScene.GetSubjectHierarchyNode()
       shNode.SetItemDisplayVisibility(int(segmentationLabelMapID), 0)
+      # Clear label map layer (the green overlay on the slice)
+      for name in layoutManager.sliceViewNames():
+        sliceWidget = layoutManager.sliceWidget(name)
+        sliceCompositeNode = sliceWidget.mrmlSliceCompositeNode()
+        sliceCompositeNode.SetLabelVolumeID("")
 
     slicer.util.forceRenderAllViews()
     slicer.app.processEvents()


### PR DESCRIPTION
### **Description**
The overlay on 2D images are cleared when resetState() is called.

This PR intends to close #60

### **Testing**
MacOS (Version 5.2.2 - Stable Release and Version 5.3.0 - Preview Release)