### PR TITLE
[Logic][NFC] Modify looping statements to simplify code

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -568,7 +568,6 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     progressDialog = qt.QProgressDialog("Creating Transform Nodes From Transformation Data", "Cancel",
                                         0, numImages)
     progressDialog.minimumDuration = 0
-    progressCount = 0
 
     # NOTE: It is very important that we loop using the number of 2D images loaded, versus the size
     # of the transforms array/list. This is because we may provide a CSV with more transforms than
@@ -624,8 +623,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       shNode.SetItemParent(transformNodeID, transformsVirtualFolderID)
 
       # Update how far we are in the progress bar
-      progressCount += 1
-      progressDialog.setValue(progressCount)
+      progressDialog.setValue(i + 1)
 
       # This render step is needed for the progress bar to visually update in the GUI
       slicer.util.forceRenderAllViews()
@@ -691,9 +689,8 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       progressDialog = qt.QProgressDialog("Loading 2D Images Into 3D Slicer", "Cancel",
                                           0, len(imageFiles))
       progressDialog.minimumDuration = 0
-      progressCount = 0
 
-      for file in imageFiles:
+      for fileIndex in range(len(imageFiles)):
         # If the 'Cancel' button was pressed, we want to return to a default state
         if progressDialog.wasCanceled:
           # Remove virtual folder and any children transform nodes
@@ -703,16 +700,15 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           self.selector2DImagesFolder.currentPath = ""
           return None, True
 
-        filepath = os.path.join(path, file)
+        filepath = os.path.join(path, imageFiles[fileIndex])
         loadedImageNode = slicer.util.loadVolume(filepath, {"singleFile": True, "show": False})
         # Place image into the virtual folder
         imageID = shNode.GetItemByDataNode(loadedImageNode)
         shNode.SetItemParent(imageID, folderID)
 
         #  Update how far we are in the progress bar
-        progressCount += 1
-        progressDialog.setValue(progressCount)
-
+        progressDialog.setValue(fileIndex + 1)
+        
         # This render step is needed for the progress bar to visually update in the GUI
         slicer.util.forceRenderAllViews()
         slicer.app.processEvents()


### PR DESCRIPTION
### **Description**
This PR removes the use of the `progressCount` accumulator variable from the `createTransformNodesFromTransformData()` and `loadImagesIntoVirtualFolder()` functions, and replaces it with for loop variables that were already in use in this codebase.

This PR intends to close #67 
### **Testing**
MacOS (Version 5.2.2 - Stable Release)