### PR TITLE
[Logic][NFC] Move `LPStoRASMatrix` outside the loop

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -910,6 +910,11 @@ class TrackLogic(ScriptedLoadableModuleLogic):
                                         0, numImages)
     progressDialog.minimumDuration = 0
 
+    # 3D Slicer works with 4x4 transform matrices internally
+    LPSToRASMatrix = vtk.vtkMatrix4x4()
+    LPSToRASMatrix.SetElement(0, 0, -1)
+    LPSToRASMatrix.SetElement(1, 1, -1)
+
     # NOTE: It is very important that we loop using the number of 2D images loaded, versus the size
     # of the transforms array/list. This is because we may provide a CSV with more transforms than
     # needed, but we only need to create as many transform nodes as there are 2D images.
@@ -933,11 +938,6 @@ class TrackLogic(ScriptedLoadableModuleLogic):
       # |ΔIS|   | 0  0  1  0|   |Z|
       # \ 0 /   \ 0  0  0  1/   \0/
       # Where X, Y, and Z represent the transformation in LPS.
-
-      # 3D Slicer works with 4x4 transform matrices internally
-      LPSToRASMatrix = vtk.vtkMatrix4x4()
-      LPSToRASMatrix.SetElement(0, 0, -1)
-      LPSToRASMatrix.SetElement(1, 1, -1)
 
       # Convert transform from LPS to RAS
       currentTransform = transforms[i]


### PR DESCRIPTION
### **Description**
This PR relocates the initialization of the `LPSToRASMatrix` variable from within the loop to before the loop begins. This change allows the variable to be defined before the start of the loop.

This PR intends to close #88 

### **Testing**
Tested on MacOS (Version 5.3.0 - Preview Release)