### PR TITLE
Remove filename restrictions for Transforms Files and support multiple extensions

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1,4 +1,5 @@
 import csv
+import pandas as pd
 import os
 import re
 
@@ -887,6 +888,42 @@ class TrackLogic(ScriptedLoadableModuleLogic):
             # If there was an error reading the values, break out because we can't/shouldn't
             # perform the playback if the transformation data is corrupt or missing.
             break
+
+    if re.match('.*\.(csv|xls|xlsx|txt)', filepath):
+    
+      if filepath.endswith('.csv'):
+        with open(filepath, "r") as f:
+          # Using a DictReader allows us to recognize the CSV header
+          reader = csv.DictReader(f)
+          for row in reader:
+            # Extract floating point values from row
+            try:
+              transformationsList.append([float(row['X']), float(row['Y']), float(row['Z'])])
+            except:
+              # If there was an error reading the values, break out because we can't/shouldn't
+              # perform the playback if the transformation data is corrupt or missing.
+              break
+              
+      elif filepath.endswith('.xls') or filepath.endswith('.xlsx'):
+        df = pd.read_excel(filepath)
+        try:
+          transformationsList = df[['X', 'Y', 'Z']].astype(float).values.tolist()
+        except:
+          # If there was an error reading the values, break out because we can't/shouldn't
+          # perform the playback if the transformation data is corrupt or missing.
+          pass
+          
+      elif filepath.endswith('.txt'):
+        with open(filepath, "r") as f:
+          next(f)
+          for line in f:
+            values = line.strip().split(',')
+            print(values)
+            try:
+              x, y, z = map(float, values)
+              transformationsList.append([x, y, z])
+            except:
+              break
 
     if len(transformationsList) < numImages:
       return None


### PR DESCRIPTION
### **Description**
This PR intends to accept different Transforms filetypes in the "Inputs" section of our extension. The Transforms File would accept filetypes of .csv .xls .xlsx .txt
### **Testing**
Tested on MacOS (Version 5.3.0 - Preview Release)