### PR TITLE
Update displayed image when sequence slider moved

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -966,27 +966,19 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                            self.customParamNode.overlayAsOutline)
 
   def onSkipImages(self):
-    # """
-    # Called when the user clicks & drags the slider either forwards or backwards
-    # """
-    if self.currentFrameInputBox.value != 1:
-      self.customParamNode.sequenceBrowserNode.SetSelectedItemNumber(self.currentFrameInputBox.value - 2)
-      self.logic.visualize(self.customParamNode.sequenceBrowserNode,
-                           self.customParamNode.sequenceNode2DImages,
-                           self.customParamNode.node3DSegmentationLabelMap,
-                           self.customParamNode.sequenceNodeTransforms,
-                           self.customParamNode.opacity,
-                           self.customParamNode.overlayAsOutline)
-      self.onIncrement()
-    else:
-      self.customParamNode.sequenceBrowserNode.SetSelectedItemNumber(1)
-      self.logic.visualize(self.customParamNode.sequenceBrowserNode,
-                           self.customParamNode.sequenceNode2DImages,
-                           self.customParamNode.node3DSegmentationLabelMap,
-                           self.customParamNode.sequenceNodeTransforms,
-                           self.customParamNode.opacity,
-                           self.customParamNode.overlayAsOutline)
-      self.onDecrement()
+    """
+    Called when the user clicks & drags the slider either forwards or backwards, or manually edits the spinBox's value
+    """
+    num = self.currentFrameInputBox.value
+    self.resetVisuals(False)
+    self.sequenceSlider.setValue(num)
+    self.customParamNode.sequenceBrowserNode.SetSelectedItemNumber(num - 1)
+    self.logic.visualize(self.customParamNode.sequenceBrowserNode,
+                         self.customParamNode.sequenceNode2DImages,
+                         self.customParamNode.node3DSegmentationLabelMap,
+                         self.customParamNode.sequenceNodeTransforms,
+                         self.customParamNode.opacity,
+                         self.customParamNode.overlayAsOutline)
     
     
   def updatePlaybackButtons(self, inputsProvided):
@@ -1104,7 +1096,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
     return self.customParamNode.sequenceBrowserNode.GetSelectedItemNumber() == (self.customParamNode.totalImages - 1)
 
-  def resetVisuals(self):
+  def resetVisuals(self, reset=True):
     """
     Resets the visual state of the 3D Slicer views. This function is called when one of the main
     inputs is changed.
@@ -1140,7 +1132,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     inputsProvided = self.customParamNode.sequenceNode2DImages and \
                      self.customParamNode.sequenceNodeTransforms and \
                      self.customParamNode.node3DSegmentation
-    if inputsProvided:
+    if inputsProvided and reset:
       # Reset the Sequence back to the first image
       self.customParamNode.sequenceBrowserNode.SetPlaybackActive(False)
       self.customParamNode.sequenceBrowserNode.SetSelectedItemNumber(0)

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -414,7 +414,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.previousFrameButton.connect("clicked(bool)", self.onDecrement)
     self.sequenceSlider.connect("valueChanged(int)",
                                 lambda: self.currentFrameInputBox.setValue(self.sequenceSlider.value))
-    self.sequenceSlider.connect("sliderReleased()", self.skipImages)
+    self.sequenceSlider.connect("sliderReleased()", self.onSkipImages)
     self.currentFrameInputBox.connect("valueChanged(int)",
                                 lambda: self.sequenceSlider.setValue(self.currentFrameInputBox.value))
     self.currentFrameInputBox.connect("upButtonClicked()", self.onIncrement)

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -419,6 +419,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                                 lambda: self.sequenceSlider.setValue(self.currentFrameInputBox.value))
     self.currentFrameInputBox.connect("upButtonClicked()", self.onIncrement)
     self.currentFrameInputBox.connect("downButtonClicked()", self.onDecrement)
+    self.currentFrameInputBox.connect("editingFinished()", self.onSkipImages)
     self.playbackSpeedBox.connect("valueChanged(double)", self.onPlaybackSpeedChange)
     self.opacitySlider.connect("valueChanged(double)", self.onOpacityChange)
     self.overlayOutlineOnlyBox.connect("toggled(bool)", self.onOverlayOutlineChange)

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -964,18 +964,10 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                            self.customParamNode.opacity,
                            self.customParamNode.overlayAsOutline)
 
-  def skipImages(self):
+  def onSkipImages(self):
     # """
     # Called when the user clicks & drags the slider either forwards or backwards
     # """
-    # if start < finish: # User wants to move forward in the image sequence
-    #   for _ in range(start, finish):
-    #     self.onIncrement()
-    # elif start > finish: # User wants to move backwards in the image sequence 
-    #   for _ in range(start, finish, -1):
-    #     self.onDecrement()
-    # self.customParamNode.sequenceBrowserNode.SetSelectedItemNumber(self.currentFrameInputBox.value - 1)
-    # self.currentFrameInputBox.setValue(self.sequenceSlider.value)
     if self.currentFrameInputBox.value != 1:
       self.customParamNode.sequenceBrowserNode.SetSelectedItemNumber(self.currentFrameInputBox.value - 2)
       self.logic.visualize(self.customParamNode.sequenceBrowserNode,
@@ -996,7 +988,6 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.onDecrement()
     
     
-  
   def updatePlaybackButtons(self, inputsProvided):
     """
     Function to update which playback buttons are enabled or disabled according to the state.
@@ -1580,7 +1571,7 @@ class TrackLogic(ScriptedLoadableModuleLogic):
     
     sliceWidget = self.getSliceWidget(layoutManager, proxy2DImageNode)
 
-    name = sliceWidget.sliceViewName # This is important I think, as it grabs the specific slice we wanna update
+    name = sliceWidget.sliceViewName
         
     sliceCompositeNode = sliceWidget.mrmlSliceCompositeNode()
 
@@ -1645,7 +1636,6 @@ class TrackLogic(ScriptedLoadableModuleLogic):
       if currentSlice is not None:
         slicer.mrmlScene.GetNodeByID(f"vtkMRMLSliceCompositeNode{color}").SetBackgroundVolumeID(currentSlice.GetID())
         imageFileNameText = slicer.mrmlScene.GetNodeByID(f"vtkMRMLSliceCompositeNode{color}").GetNodeReference('backgroundVolume').GetAttribute('Sequences.BaseName')
-        # print(imageFileNameText) # I have found what updates the text of the UI
         # Place "Current Alignment" text in the slice view corner
         sliceViewWindow = slicer.app.layoutManager().sliceWidget(color).sliceView()
         sliceViewWindow.cornerAnnotation().SetText(0, imageFileNameText)


### PR DESCRIPTION
## Description

This PR intends to make the following changes:
-  Update the displayed image when the slider under 'sequence' is moved, either by dragging the slider or clicking on the slider

A minor change was made as well:
- Update the displayed image when the arrow buttons are pressed on the spinbox containing the current image number

## Testing
Tested on MacOS (Version 5.4.0 - Stable Release)
