### PR TITLE
Resolve image skipping bug when increasing playback speed while playing sequence

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -876,6 +876,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     Begin the playback when a user clicks the "Play" button and pause when user clicks the "Pause" button.
     """
     layoutManager = slicer.app.layoutManager()
+    self.customParamNode.sequenceBrowserNode.SetPlaybackItemSkippingEnabled(False) # Fixes image skipping bug on slower machines
     proxy2DImageNode = self.customParamNode.sequenceBrowserNode.GetProxyNode(self.customParamNode.sequenceNode2DImages)
     sliceWidget = TrackLogic().getSliceWidget(layoutManager, proxy2DImageNode)
     # Fit the slice to the current background image


### PR DESCRIPTION
## Description

This PR intends to make the following change:
- Fix image skipping bug when increasing playback speed while playing sequence

## Testing
Tested on Windows 10 (Version 5.4.0 - Stable Release)