### PR TITLE
Add a "Help & Acknowledgment" section to the extension

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -33,12 +33,18 @@ class Track(ScriptedLoadableModule):
     self.parent.contributors = ["James McCafferty (laboratory-for-translational-medicine)",
                                 "Fabyan Mikhael (laboratory-for-translational-medicine)",
                                 "HaPhan Tran (laboratory-for-translational-medicine)",
-                                "Mubariz Afzal (laboratory-for-translational-medicine)"]
-    # TODO: update with short description of the module and a link to online module documentation
-    self.parent.helpText = """"""
-    # TODO: replace with organization, grant and thanks
+                                "Mubariz Afzal (laboratory-for-translational-medicine)",
+                                "Teo Mesrkhani (laboratory-for-translational-medicine)",
+                                "Jacqueline Banh (laboratory-for-translational-medicine)",
+                                "Nicholas Caro Lopez (laboratory-for-translational-medicine)",
+                                "Venkat Guru Prasad (laboratory-for-translational-medicine)",
+                                ]
+    self.parent.helpText = """From the input dropdown, select valid 2D cine images in the Cine
+    Images Folder, a target to track in the 3D Segmentation File, and a transforms file containing information
+    about the X,Y,Z coordinates of exactly where the target is. <br> <br>
+    For more information see <a href="https://slicertrack.github.io/">the online documentation</a>"""
     self.parent.acknowledgementText = """
-    This file was originally developed by James McCafferty, Fabyan Mikhael, HaPhan Tran, and Mubariz Afzal.
+This extension was developed by the Laboratory for Translational Medicine.
 """
 
 #


### PR DESCRIPTION
This PR intends to add a "Help & Acknowledgment" section to SlicerTrack, which includes a description to the extension, link to the website (https://slicertrack.github.io/), acknowledgments, and contributors to SlicerTrack.

This section appears on all other extensions available on 3D Slicer.