### PR TITLE
Added tooltip for stop button

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -129,7 +129,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.selector2DImagesFolder.settingKey = '2DImagesFolder'
     self.inputsFormLayout.addRow("Cine Images Folder:", self.selector2DImagesFolder)
     
-    tooltipText = "Insert 2D images in .mha format."
+    tooltipText = "Insert Cine images in .mha format."
     self.selector2DImagesFolder.setToolTip(tooltipText)
     browseButton = self.selector2DImagesFolder.findChildren(qt.QToolButton)[0]
     browseButton.setToolTip(tooltipText)
@@ -138,9 +138,9 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.selector3DSegmentation = ctk.ctkPathLineEdit()
     self.selector3DSegmentation.filters = ctk.ctkPathLineEdit.Files | ctk.ctkPathLineEdit.Executable | ctk.ctkPathLineEdit.NoDot | ctk.ctkPathLineEdit.NoDotDot | ctk.ctkPathLineEdit.Readable
     self.selector3DSegmentation.settingKey = '3DSegmentation'
-    self.inputsFormLayout.addRow("3D Segmentation File:", self.selector3DSegmentation)
+    self.inputsFormLayout.addRow("Segmentation File:", self.selector3DSegmentation)
     
-    tooltipText = "Insert a 3D segmentation file in .mha format."
+    tooltipText = "Insert a Segmentation file in .mha format."
     self.selector3DSegmentation.setToolTip(tooltipText)
     browseButton = self.selector3DSegmentation.findChildren(qt.QToolButton)[0]
     browseButton.setToolTip(tooltipText)

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1018,6 +1018,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.previousFrameButton.setToolTip("Move to the previous frame.")
         self.nextFrameButton.setToolTip("Move to the next frame.")
         self.playSequenceButton.setToolTip("Stop playback at the current frame.")
+        self.stopSequenceButton.setToolTip("Return to the first frame.")
 
         # Set the play button to be a pause button
         self.playSequenceButton.setIcon(pause_icon)


### PR DESCRIPTION
## Description

This PR intends to make the following changes:
- Created tooltip for stop sequence button letting the user know that clicking it will take the slider back to Image 1

A minor change was made as well:
- Removed "2D" from Cine Images Folder input & "3D" from Segmentation File Input

## Testing
Tested on MacOS (Version 5.6.0 - Stable Release)