### PR TITLE
Add support for .dcm images

### DIFF
--- a/Track/utils/TrackLogic.py
+++ b/Track/utils/TrackLogic.py
@@ -52,7 +52,7 @@ class TrackLogic(ScriptedLoadableModuleLogic):
     # Find all the image file names within the provided dir
     imageFiles = []
     for item in os.listdir(path):
-      if re.match('.*\.mha', item): # Only look for .mha files
+      if re.match('.*\.mha', item) or re.match('.*\.dcm', item): # Only look for .mha and .dcm files
         imageFiles.append(item)
     imageFiles.sort()
 


### PR DESCRIPTION
###Description
This PR intends to make the following changes:

Add support for loading Cine Images in Dicom (.dcm) format

### Testing
Tested on Windows (Version 5.6.1 - Stable Release)