### PR TITLE
Keep apply button enable after clicked

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -109,7 +109,9 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.logic = None
     self.customParamNode = None
     self._updatingGUIFromParameterNode = False
-
+  def onColumnXSelectorChange(self):
+    print('reach listerners')
+    self.applyTransformButton.enabled = True
   def setup(self):
     """
     Called when the user opens the module the first time and the widget is initialized.
@@ -430,9 +432,9 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.selectorTransformsFile.connect("currentPathChanged(QString)", \
       self.onTransformsFilePathChange)
     
-    self.columnXSelector.connect("currentTextChanged()", lambda: self.updateGUIFromParameterNode("anyColumnSelector", "currentTextChanged"))
-    self.columnYSelector.connect("currentTextChanged()", lambda: self.updateGUIFromParameterNode("anyColumnSelector", "currentTextChanged"))
-    self.columnZSelector.connect("currentTextChanged()", lambda: self.updateGUIFromParameterNode("anyColumnSelector", "currentTextChanged"))
+    self.columnXSelector.connect("currentTextChanged(QString)", self.onColumnXSelectorChange)
+    self.columnYSelector.connect("currentTextChanged(QString)", self.onColumnXSelectorChange)
+    self.columnZSelector.connect("currentTextChanged(QString)", self.onColumnXSelectorChange)
     
     self.applyTransformButton.connect("clicked(bool)", \
       lambda: self.updateParameterNodeFromGUI("applyTransformsButton", "clicked"))
@@ -553,11 +555,6 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     else:
       self.selectorTransformsFile.enabled = False
       self.selectorTransformsFile.setToolTip("Load a valid Cine Images Folder to enable loading a Transforms file.")
-
-    # self.columnZSelector.connect("currentTextChanged()", lambda: self.updateGUIFromParameterNode("anyColumnSelector", "currentTextChanged"))
-    if caller == "anyColumnSelector" and event == "currentTextChanged":
-      print("Column Selector Changed")
-      self.applyTransformButton.enabled = True  # Enable the "Apply Transformation" button to assure the user can apply again
 
     # True if the 2D images, transforms and 3D segmentation have been provided
     inputsProvided = self.customParamNode.sequenceNode2DImages and \
@@ -1247,6 +1244,7 @@ class TrackTest(ScriptedLoadableModuleTest):
   def test_load_inputs(self):
     """ Test if we can load all inputs
     """
+    print('==================== Start test ====================')
     data_folder_path = os.path.join(os.path.dirname(slicer.util.modulePath(self.__module__)),
                                   'Data')
     csv_file_path = os.path.join(data_folder_path, 'Transforms.csv')
@@ -1266,3 +1264,5 @@ class TrackTest(ScriptedLoadableModuleTest):
     self.assertTrue(transformationList is not None)
     
     self.delayDisplay('Test passed')
+    print('==================== End test ====================')
+    

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -430,9 +430,9 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.selectorTransformsFile.connect("currentPathChanged(QString)", \
       self.onTransformsFilePathChange)
     
-    self.columnXSelector.connect("currentTextChanged()", lambda: self.updateParameterNodeFromGUI("anyColumnSelector", "currentTextChanged"))
-    self.columnYSelector.connect("currentTextChanged()", lambda: self.updateParameterNodeFromGUI("anyColumnSelector", "currentTextChanged"))
-    self.columnZSelector.connect("currentTextChanged()", lambda: self.updateParameterNodeFromGUI("anyColumnSelector", "currentTextChanged"))
+    self.columnXSelector.connect("currentTextChanged()", lambda: self.updateGUIFromParameterNode("anyColumnSelector", "currentTextChanged"))
+    self.columnYSelector.connect("currentTextChanged()", lambda: self.updateGUIFromParameterNode("anyColumnSelector", "currentTextChanged"))
+    self.columnZSelector.connect("currentTextChanged()", lambda: self.updateGUIFromParameterNode("anyColumnSelector", "currentTextChanged"))
     
     self.applyTransformButton.connect("clicked(bool)", \
       lambda: self.updateParameterNodeFromGUI("applyTransformsButton", "clicked"))
@@ -539,7 +539,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     
     if self.customParamNode is None or self._updatingGUIFromParameterNode:
       return
-
+    
     # Make sure GUI changes do not call updateParameterNodeFromGUI (it could cause infinite loop)
     self._updatingGUIFromParameterNode = True
 
@@ -554,7 +554,10 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.selectorTransformsFile.enabled = False
       self.selectorTransformsFile.setToolTip("Load a valid Cine Images Folder to enable loading a Transforms file.")
 
-
+    # self.columnZSelector.connect("currentTextChanged()", lambda: self.updateGUIFromParameterNode("anyColumnSelector", "currentTextChanged"))
+    if caller == "anyColumnSelector" and event == "currentTextChanged":
+      print("Column Selector Changed")
+      self.applyTransformButton.enabled = True  # Enable the "Apply Transformation" button to assure the user can apply again
 
     # True if the 2D images, transforms and 3D segmentation have been provided
     inputsProvided = self.customParamNode.sequenceNode2DImages and \
@@ -735,9 +738,6 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                                    "The file was not loaded into 3D Slicer.", "Input Error")
     
 
-    if caller == "anyColumnSelector" and event == "currentTextChanged":
-        print('we get here')
-        self.applyTransformButton.enabled = True
                            
     if caller == "applyTransformsButton" and event == "clicked":
       # Set a param to hold the path to the transformations .csv file

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -429,16 +429,18 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       lambda: self.updateParameterNodeFromGUI("selector3DSegmentation", "currentPathChanged"))
     self.selectorTransformsFile.connect("currentPathChanged(QString)", \
       self.onTransformsFilePathChange)
+    
+    self.columnXSelector.connect("currentTextChanged()", lambda: self.updateParameterNodeFromGUI("anyColumnSelector", "currentTextChanged"))
+    self.columnYSelector.connect("currentTextChanged()", lambda: self.updateParameterNodeFromGUI("anyColumnSelector", "currentTextChanged"))
+    self.columnZSelector.connect("currentTextChanged()", lambda: self.updateParameterNodeFromGUI("anyColumnSelector", "currentTextChanged"))
+    
     self.applyTransformButton.connect("clicked(bool)", \
       lambda: self.updateParameterNodeFromGUI("applyTransformsButton", "clicked"))
 
     # These connections will reset the visuals when one of the main inputs are modified
     self.selector2DImagesFolder.connect("currentPathChanged(QString)", self.resetVisuals)
     self.selector3DSegmentation.connect("currentPathChanged(QString)", self.resetVisuals)
-    # comment out this line because we only reset visuals when click apply transform button now
-    # self.selectorTransformsFile.connect("currentPathChanged(QString)", self.resetVisuals)
     
-    # self.applyTransformButton.connect("clicked(bool)", self.resetVisuals)
     
 
     #
@@ -534,6 +536,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     This method is called whenever parameter node is changed.
     The module GUI is updated to show the current state of the parameter node.
     """
+    
     if self.customParamNode is None or self._updatingGUIFromParameterNode:
       return
 
@@ -592,9 +595,8 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self._updatingGUIFromParameterNode = False
     
     # Disable the "Apply Transformation" button to assure the user the Transformation is applied
-    # self.applyTransformButton.enabled = False
-    # commented out this to allow users to reapply transformation if they want to (after change columns selection)
-    # here is the link to the issue: https://trello.com/c/oQHynsbv/19-cannot-update-columns-once-transformation-is-applied
+    self.applyTransformButton.enabled = False
+    
 
   def updateParameterNodeFromGUI(self, caller=None, event=None):
     """
@@ -732,7 +734,10 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         slicer.util.warningDisplay("The provided 3D segmentation was not of the .mha file type. "
                                    "The file was not loaded into 3D Slicer.", "Input Error")
     
-          
+
+    if caller == "anyColumnSelector" and event == "currentTextChanged":
+        print('we get here')
+        self.applyTransformButton.enabled = True
                            
     if caller == "applyTransformsButton" and event == "clicked":
       # Set a param to hold the path to the transformations .csv file

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -110,8 +110,10 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.customParamNode = None
     self._updatingGUIFromParameterNode = False
   def onColumnXSelectorChange(self):
-    print('reach listerners')
     self.applyTransformButton.enabled = True
+    self.transformationAppliedLabel.setVisible(False)
+    
+    
   def setup(self):
     """
     Called when the user opens the module the first time and the widget is initialized.

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -592,7 +592,9 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self._updatingGUIFromParameterNode = False
     
     # Disable the "Apply Transformation" button to assure the user the Transformation is applied
-    self.applyTransformButton.enabled = False
+    # self.applyTransformButton.enabled = False
+    # commented out this to allow users to reapply transformation if they want to (after change columns selection)
+    # here is the link to the issue: https://trello.com/c/oQHynsbv/19-cannot-update-columns-once-transformation-is-applied
 
   def updateParameterNodeFromGUI(self, caller=None, event=None):
     """


### PR DESCRIPTION
Tested on Mac, Slicer 5.6.1 stable
After click apply, the button greyed out
![image](https://github.com/laboratory-for-translational-medicine/SlicerTrack/assets/47532906/3ef8131e-7a15-4722-a33a-ec8089ca0d25)
If User change 1 of the 3 column selector, the button is enable again, and the text "Transformation Applied" is hidden.
![image](https://github.com/laboratory-for-translational-medicine/SlicerTrack/assets/47532906/21b89e34-4add-4be5-af1c-d8d759fd1834)
From here, user can click Apply again and continue to view the sequence. 