### PR TITLE
Bug fix reuploading files when active sequence

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -21,7 +21,6 @@
 import os
 import csv
 import re
-import time
 
 import ctk
 import qt
@@ -1227,6 +1226,15 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     pause_icon = qt.QIcon(os.path.join(mediaIconsPath, 'pause.png'))
     play_icon = qt.QIcon(os.path.join(mediaIconsPath, 'play.png'))
     self.playSequenceButton.setIconSize(iconSize)
+    
+    # Reset file deletion and tooltips
+    self.deleteImagesButton.enabled = True
+    self.deleteSegmentationButton.enabled = True
+    self.deleteTransformsButton.enabled = True
+    self.deleteImagesButton.setToolTip("Remove Cine images.")
+    self.deleteSegmentationButton.setToolTip("Remove Segmentation file.")
+    self.deleteTransformsButton.setToolTip("Remove Transforms file.")
+    
     if inputsProvided:
 
       self.divisionFrameLabel.enabled = True
@@ -1241,10 +1249,18 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.nextFrameButton.setToolTip("Move to the next frame.")
         self.playSequenceButton.setToolTip("Pause playback at current frame.")
         self.stopSequenceButton.setToolTip("Return to the first frame.")
+        self.deleteImagesButton.setToolTip("Pause the player to enable this feature.")
+        self.deleteSegmentationButton.setToolTip("Pause the player to enable this feature.")
+        self.deleteTransformsButton.setToolTip("Pause the player to enable this feature.")
 
         # Set the play button to be a pause button
         self.playSequenceButton.setIcon(pause_icon)
         self.playSequenceButton.enabled = True
+        
+        # Enable file deletion
+        self.deleteImagesButton.enabled = False
+        self.deleteSegmentationButton.enabled = False
+        self.deleteTransformsButton.enabled = False
 
         self.stopSequenceButton.enabled = True
         self.nextFrameButton.enabled = False
@@ -1253,12 +1269,20 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.sequenceSlider.enabled = False
       else:
         self.sequenceSlider.setToolTip("Select the next frame for playback.")
+        self.deleteImagesButton.setToolTip("Remove Cine images.")
+        self.deleteSegmentationButton.setToolTip("Remove Segmentation file.")
+        self.deleteTransformsButton.setToolTip("Remove Transforms file.")
         
         # If we are paused
         self.playSequenceButton.setIcon(play_icon)
         self.currentFrameInputBox.enabled = True
         self.sequenceSlider.enabled = True
         self.playSequenceButton.setToolTip("Play playback at current frame.")
+        
+        # Enable file deletion
+        self.deleteImagesButton.enabled = True
+        self.deleteSegmentationButton.enabled = True
+        self.deleteTransformsButton.enabled = True
 
         if self.atLastImage():
           #self.nextFrameButton.setToolTip("Move to the previous frame.") - may add a different tooltip at last image

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -758,7 +758,6 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                      hasattr(self.customParamNode.sequenceBrowserNode, 'GetPlaybackActive') and \
                      self.customParamNode.sequenceBrowserNode.GetPlaybackActive()
         if activePlay:
-          print("We need to delete stuff")
           # Remove the unused Sequence Browser if it exists
           nodes = slicer.mrmlScene.GetNodesByClass("vtkMRMLSequenceBrowserNode")
           nodes.UnRegister(None)
@@ -784,7 +783,6 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           # This is what isn't working
           # Remove the unused Image Nodes Sequence node, containing each image node, if it exists
           nodes = slicer.mrmlScene.GetNodesByClassByName("vtkMRMLScalarVolumeNode", "Image Nodes Sequence")
-          print(nodes)
           nodes.UnRegister(None)
           if nodes.GetNumberOfItems() == 1:
             nodeToRemove = nodes.GetItemAsObject(0)

--- a/Track/utils/TrackLogic.py
+++ b/Track/utils/TrackLogic.py
@@ -493,10 +493,12 @@ class TrackLogic(ScriptedLoadableModuleLogic):
       # Add desired text to slice views that have a background node
       if currentSlice is not None:
         slicer.mrmlScene.GetNodeByID(f"vtkMRMLSliceCompositeNode{color}").SetBackgroundVolumeID(currentSlice.GetID())
-        imageFileNameText = slicer.mrmlScene.GetNodeByID(f"vtkMRMLSliceCompositeNode{color}").GetNodeReference('backgroundVolume').GetAttribute('Sequences.BaseName')
-        # Place "Current Alignment" text in the slice view corner
-        sliceViewWindow = slicer.app.layoutManager().sliceWidget(color).sliceView()
-        sliceViewWindow.cornerAnnotation().SetText(0, imageFileNameText)
+        imageFile = slicer.mrmlScene.GetNodeByID(f"vtkMRMLSliceCompositeNode{color}").GetNodeReference('backgroundVolume') is not None
+        if imageFile:
+          imageFileNameText = slicer.mrmlScene.GetNodeByID(f"vtkMRMLSliceCompositeNode{color}").GetNodeReference('backgroundVolume').GetAttribute('Sequences.BaseName')
+          # Place "Current Alignment" text in the slice view corner
+          sliceViewWindow = slicer.app.layoutManager().sliceWidget(color).sliceView()
+          sliceViewWindow.cornerAnnotation().SetText(0, imageFileNameText)
     
     for color in self.backgrounds:
       sliceViewWindow = slicer.app.layoutManager().sliceWidget(color).sliceView()


### PR DESCRIPTION
## Description

This PR intends to make the following change:
- Fixed the bug occurring when the user actively already has a dataset playing with SlicerTrack, and tries to reupload new Cine Images or a new Segmentation file

A minor change was made as well:
- Fixed the bug occurring while the user tries to delete any of the files uploaded into SlicerTrack while the sequence is actively playing

## Testing
Tested on MacOS (Version 5.6.1 - Stable Release)