### PR TITLE
Bug fix reuploading transforms file in sequence

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1058,7 +1058,33 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       
       self.transformationAppliedLabel.setVisible(False)
       self.applyTransformButton.enabled = True
-      
+
+    def onSequenceChange(self):
+      """
+      Allows for the reuploading of transforms file during active sequence
+      """
+      # Check if sequence is actively playing
+      activePlay = self.customParamNode.sequenceBrowserNode and \
+        hasattr(self.customParamNode.sequenceBrowserNode, 'GetPlaybackActive') and \
+        self.customParamNode.sequenceBrowserNode.GetPlaybackActive()
+
+      if activePlay:
+        # Stop sequence
+        self.customParamNode.sequenceBrowserNode.SetPlaybackActive(False)
+
+        # Removes existing transforms nodes and sequence nodes
+        nodes = slicer.mrmlScene.GetNodesByClassByName("vtkMRMLLinearTransformNode", "Transform Nodes Sequence")
+        nodes.UnRegister(None)
+        for node in nodes:
+          slicer.mrmlScene.RemoveNode(node)
+
+        nodes = slicer.mrmlScene.GetNodesByClassByName("vtkMRMLSequenceNode", "Transform Nodes Sequence")
+        nodes.UnRegister(None)
+        for node in nodes:
+            slicer.mrmlScene.RemoveNode(node)
+
+    onSequenceChange(self)
+
     clearColumnSeletors(self)
       
     addItemToColumnSeletors(self, self.logic.getColumnNamesFromTransformsInput(self.selectorTransformsFile.currentPath))

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1063,6 +1063,10 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       """
       Allows for the reuploading of transforms file during active sequence
       """
+      # Changes transforms file path to new one
+      if self.customParamNode.transformsFilePath != self.selectorTransformsFile.currentPath:
+        self.customParamNode.transformsFilePath = self.selectorTransformsFile.currentPath
+
       # Check if sequence is actively playing
       activePlay = self.customParamNode.sequenceBrowserNode and \
         hasattr(self.customParamNode.sequenceBrowserNode, 'GetPlaybackActive') and \


### PR DESCRIPTION
## Description

This PR intends to make the following changes:
- Allows for the user to upload a new transforms file while the sequence is active with another data set

## Testing
Tested on Windows (Version 5.6.1 - Stable Release)