### PR TITLE
Drop Down Menu Change

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -48,7 +48,7 @@ class Track(ScriptedLoadableModule):
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)
     self.parent.title = "Track"
-    self.parent.categories = ["Tracking"]
+    self.parent.categories = ["SlicerTrack"]
     self.parent.dependencies = []
     self.parent.contributors = ["James McCafferty (laboratory-for-translational-medicine)",
                                 "Fabyan Mikhael (laboratory-for-translational-medicine)",


### PR DESCRIPTION
## Description

This PR intends to make the following changes:
- When selecting SlicerTrack in the drop-down menu, it will now say SlicerTrack instead of Tracking

## Testing
Tested on Windows (Version 5.6.1 - Stable Release)


