### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,14 @@ set(EXTENSION_CONTRIBUTORS "Elodie Lugez (Toronto Metropolitan University), \
                             Nicholas Caro Lopez (Toronto Metropolitan University), \
                             Venkat Guru Prasad (Toronto Metropolitan University), \
                             Sayeed Jalil (Toronto Metropolitan University)")
-set(EXTENSION_DESCRIPTION "Module providing tracking tools and displacement visualizations")
+set(EXTENSION_DESCRIPTION "SlicerTrack is open-source, extendable, developed in Python as an extension on the highly successful 3D Slicer platform. SlicerTrack extension enables target tracking visualization by replaying cine 2D images and overlays the outline of the Region of interest (ROI) using a displacement data file.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/slicertrack/slicertrack.github.io/main/resources/SlicerTrack_logo.png")
-set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/slicertrack/slicertrack.github.io/main/resources/screenshots/ST_Document1.png https://raw.githubusercontent.com/slicertrack/slicertrack.github.io/main/resources/screenshots/ST_Document2.png https://raw.githubusercontent.com/slicertrack/slicertrack.github.io/main/resources/screenshots/ST_Document3.png https://raw.githubusercontent.com/slicertrack/slicertrack.github.io/main/resources/screenshots/ST_Document5.png")
+set(EXTENSION_SCREENSHOTURLS
+  "https://raw.githubusercontent.com/slicertrack/slicertrack.github.io/main/resources/screenshots/ST_Document1.png"
+  "https://raw.githubusercontent.com/slicertrack/slicertrack.github.io/main/resources/screenshots/ST_Document2.png"
+  "https://raw.githubusercontent.com/slicertrack/slicertrack.github.io/main/resources/screenshots/ST_Document3.png"
+  "https://raw.githubusercontent.com/slicertrack/slicertrack.github.io/main/resources/screenshots/ST_Document5.png"
+)
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized in the ExtensionsIndex repository.

Set `EXTENSION_SCREENSHOTURLS` as a list leveraging support introduced in Slicer/Slicer@1b9bd54b06 (`ENH: Support specifying screenshot url extension metadata as string or list`, 2024-04-16)

Related pull requests:
* https://github.com/Slicer/Slicer/pull/7720
* https://github.com/Slicer/ExtensionsIndex/pull/2030